### PR TITLE
fix typescript errors and more

### DIFF
--- a/src/api/types/general.ts
+++ b/src/api/types/general.ts
@@ -19,4 +19,14 @@ type Domain = {
   provider: string
 }
 
-export { Mapping, Provider, Domain }
+type ServiceResponse = {
+  success: boolean
+  message: string
+}
+
+type ProviderService = {
+  getDomains: Function
+  setRecord: Function
+}
+
+export { Mapping, Provider, Domain, ServiceResponse, ProviderService }

--- a/src/providers/goDaddy.ts
+++ b/src/providers/goDaddy.ts
@@ -3,7 +3,7 @@
 
 import { sendRequest } from '../helpers/httpRequest'
 import { getProviderKeys } from '../api/lib/data'
-import { Provider } from '../api/types/general'
+import { Provider, ServiceResponse } from '../api/types/general'
 import { ServiceKey } from '../api/types/admin'
 
 const name = 'Godaddy'
@@ -24,7 +24,7 @@ const getKeys = (): ServiceKey[] => {
   return keys as ServiceKey[]
 }
 const findKey = (key: string): string => {
-  return getKeys().find(k => k.key === key).value
+  return (getKeys().find(k => k.key === key) || { value: '' }).value
 }
 
 export const getDomains = async (): Promise<Provider> => {
@@ -52,8 +52,7 @@ export const getDomains = async (): Promise<Provider> => {
 export const setRecord = async (
   domain: string,
   ipaddress: string
-): Promise<any> => {
-  let setRecord = []
+): Promise<ServiceResponse> => {
   const url = `${service}/v1/domains/${domain}/records`
   const data = [
     {
@@ -77,6 +76,16 @@ export const setRecord = async (
     body: JSON.stringify(data)
   }
 
-  setRecord = await sendRequest<Array<any>>(url, options)
-  return { setRecord }
+  const response: ServiceResponse = {
+    success: true,
+    message: 'Successfully set CNAME records for wildcard domain'
+  }
+  try {
+    await sendRequest<Array<any>>(url, options)
+  } catch (e) {
+    console.log('Error setting API')
+    response.success = false
+    response.message = 'Error setting API'
+  }
+  return response
 }

--- a/src/providers/goDaddy.ts
+++ b/src/providers/goDaddy.ts
@@ -83,7 +83,7 @@ export const setRecord = async (
   try {
     await sendRequest<Array<any>>(url, options)
   } catch (e) {
-    console.log('Error setting API')
+    console.log('Error setting API', e)
     response.success = false
     response.message = 'Error setting API'
   }

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,4 +1,6 @@
 /*eslint @typescript-eslint/camelcase: 0*/
+
 export default {
-  dns_gd: require('./goDaddy') as Function
-}
+  dns_gd: require('./goDaddy')
+  // eslint-disable-next-line
+} as any

--- a/src/public/client.ts
+++ b/src/public/client.ts
@@ -12,6 +12,7 @@ const domainList: HTMLElement = helper.getElement('.domainList')
 const dropDownDomains: HTMLElement = helper.getElement('.dropdown-menu')
 let selectedHost = ''
 
+// eslint-disable-next-line
 class DomainMap {
   constructor(data: Mapping) {
     if (data.domain) {


### PR DESCRIPTION
Fixes:
1. Inconsistent response from providerServices. Created a consistent return type so client can handle responses easier.
> Should never respond with something like `{ 'cert successfully created': stdout, setRecords }`
2. Better error handling.
3. `find` sometimes returns `null`. Need to handle that to prevent production errors.